### PR TITLE
Add "now just wait" message to student preferences upon save 

### DIFF
--- a/portal/templates/portal/personal_preferences.html
+++ b/portal/templates/portal/personal_preferences.html
@@ -4,6 +4,12 @@
     <form class="form-personal" method="post">
         {% csrf_token %}
 
+        {% if preferences_popup %}
+          <div class="alert alert-{{ preferences_popup.state }}">
+            {{ preferences_popup.message }}
+          </div>
+        {% endif %}
+
         {% bootstrap_form preference %}
 
         <button class="btn btn-lg btn-primary btn-block" name="preference" type="submit">

--- a/portal/templates/portal/preferences.html
+++ b/portal/templates/portal/preferences.html
@@ -23,7 +23,7 @@
 
             {% partner_preferences student partner_popup %}
 
-            {% personal_preferences student %}
+            {% personal_preferences student preferences_popup %}
         </div>
     </div>
 {% endblock %}

--- a/portal/templatetags/preferences.py
+++ b/portal/templatetags/preferences.py
@@ -13,8 +13,8 @@ def partner_preferences(student, partner_popup):
 
 
 @register.inclusion_tag('portal/personal_preferences.html')
-def personal_preferences(student):
-    return {'preference': PreferenceForm(instance=student)}
+def personal_preferences(student, preferences_popup):
+    return {'preference': PreferenceForm(instance=student), 'preferences_popup': preferences_popup}
 
 
 @register.inclusion_tag('portal/family_view.html')

--- a/portal/utils.py
+++ b/portal/utils.py
@@ -11,6 +11,9 @@ def get_invalid_id_popup():
 def get_student_does_not_exist_popup():
     return {'message': "Failed to find student.", 'state': 'danger'}
 
+def get_on_save_wait_popup():
+    return {'message': "Preferences saved. Now just wait to be allocated to a family!", 'state': 'success'}
+
 
 def create_families_from_parents():
     if Student.objects.filter(child=False).count() % 2 != 0:

--- a/portal/views.py
+++ b/portal/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import render
 from config import ALLOW_CHILD_REGISTRATION, ALLOW_PARENT_REGISTRATION
 from portal.forms import SignUpForm, PreferenceForm, PartnerForm
 from portal.models import Student
-from portal.utils import get_invalid_id_popup, get_student_does_not_exist_popup
+from portal.utils import get_invalid_id_popup, get_student_does_not_exist_popup, get_on_save_wait_popup
 
 
 def index(request, position="child", popup=None):
@@ -36,6 +36,7 @@ def preferences(request, id):
     student = Student.objects.get(magic_id=id)
     student.activate()
     response = None
+    preferences_popup = None
 
     if request.method == 'POST':
         if 'preference' in request.POST:
@@ -43,6 +44,8 @@ def preferences(request, id):
 
             if preference.is_valid():
                 preference.save()
+
+                preferences_popup = get_on_save_wait_popup()
         elif 'partner' in request.POST:
             partner = PartnerForm(request.POST, instance=student)
 
@@ -62,4 +65,4 @@ def preferences(request, id):
             elif 'withdraw' in request.POST:
                 response = student.withdraw_proposal()
 
-    return render(request, 'portal/preferences.html', {'student': student, 'partner_popup': response})
+    return render(request, 'portal/preferences.html', {'student': student, 'partner_popup': response, 'preferences_popup': preferences_popup})


### PR DESCRIPTION
## Description
This change adds two sub-features:
- A `preferences_popup` to `personal_preferences` in a similar manner to `partner_popup`
- Adds a usage of `preferences_popup` to display `Preferences saved. Now just wait to be allocated to a family!` when preferences are successfully saved.

## Motivation and Context
Currently, saving the preferences form does not return any messages. This can create confusion where applying students do not know whether they need to take any further actions.

## How Has This Been Tested?
It appears that popups are not being tested, therefore this PR does not include any changes to tests.

## Screenshots:
![Screenshot](https://user-images.githubusercontent.com/1910781/29634721-ab2e1c2e-8842-11e7-86ad-edb098a33c6a.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **README** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
